### PR TITLE
Safe memory access

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,10 +6,11 @@
 #include "event_listener.h"
 #include "i_event.h"
 #include <iostream>
+#include <memory>
 
 class GeneralEvent : public event_manager::IEvent {
 public:
-    int GetSubType() const override {
+    [[nodiscard]] int GetSubType() const override {
         return 5;
     }
 };
@@ -27,10 +28,17 @@ int main() {
     std::cout << "Event Manager!\n\n";
 
     event_manager::EventManager eventManager;
-    GeneralEventListener eventListener1, eventListener2;
 
-    eventManager.AddSubscriber(&eventListener1);
-    eventManager.AddSubscriber(&eventListener2);
+    // Create shared pointers to event listeners
+    auto eventListener1 = std::make_shared<GeneralEventListener>();
+    auto eventListener2 = std::make_shared<GeneralEventListener>();
+
+    /*
+     * The compiler doesn't turn std::shared_ptr<Derived> to std::shared_ptr<Base> so we
+     * need a static cast. This is done at compile time so not real performance hit
+     */
+    eventManager.AddSubscriber(std::static_pointer_cast<event_manager::IEventListener<GeneralEvent>>(eventListener1));
+    eventManager.AddSubscriber(std::static_pointer_cast<event_manager::IEventListener<GeneralEvent>>(eventListener2));
 
     GeneralEvent sampleEvent;
     eventManager.TriggerEvent(sampleEvent);


### PR DESCRIPTION
## Description

Modified the EventManager class to work with weak_ptr instead of raw pointers. This prevents the EventManage class to access objects that might have been deleted by another process. 

Note that weak_ptr is used instead of shared_ptr inside the class since the EventManager should not be the owner of the listeners, it only takes ownership for a quick check.

## Major Changes
- [ / ] Modified raw pointers to weak_ptrs in the EventManager class