### PR TITLE
Implemented missing method definiton in derived classes

### DIFF
--- a/src/single_layer.cpp
+++ b/src/single_layer.cpp
@@ -57,6 +57,9 @@ public:
     void OnEvent(const GeneralEvent& event) override {
         std::cout << "Received general event: " << event.GetSubType() << std::endl;
     }
+
+    void RegisterCallback(const std::function<void()>& callback) override {}
+
 };
 
 class SampleLayer1 : public EventLayer {

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -56,6 +56,11 @@ namespace event_manager {
             eventTriggered = true;
             std::cout << "Received general event: " << event.GetSubType() << std::endl;
         }
+
+        void RegisterCallback(const std::function<void()>& callback) override {
+
+        }
+
     };
 
     class SpecificEventListener : public IEventListener<SpecificEvent> {
@@ -66,6 +71,11 @@ namespace event_manager {
             eventTriggered = true;
             std::cout << "Received specific event: " << event.GetSubType() << std::endl;
         }
+
+        void RegisterCallback(const std::function<void()>& callback) override {
+
+        }
+
     };
 
 }


### PR DESCRIPTION
## Description

The single layer example had a build error since a sample class deriving from the IEventListener was not implementing the RegisterCallback method, thus marking it as an abstract class as well.

## Major Changes
- [ / ] Modified broken class in single layer example and testing utils