### PR TITLE
General cleanup and refactor

### DIFF
--- a/include/base_event.h
+++ b/include/base_event.h
@@ -21,25 +21,14 @@ namespace event_system {
         virtual ~BaseEvent() = default;
 
         [[nodiscard]] std::type_index get_type() const {
-            return typeid(this); // Class Type
+            return typeid(*this); // Class Type
         };
 
         [[nodiscard]] std::string get_name() const {
-            return event_name;
+            return event_name_;
         };
-
-        /**
-         * @brief Get the sub-type of the event
-         *
-         * This is a virtual method that must be implemented by any derived class. It allows greater granularity
-         * withing an event type by specify a sub-type
-         *
-         * @returns Int representing a specific event sub-type/identifier
-         * @note Currently returns an int but this will be switched to an enum less error prone code.
-         */
-        [[nodiscard]] virtual int get_sub_type() const = 0; // TODO: Switch to an enum
     protected:
-        std::string event_name = get_type().name();
+        std::string event_name_ = get_type().name();
     };
 
 

--- a/include/event_emitter.h
+++ b/include/event_emitter.h
@@ -22,9 +22,9 @@ namespace event_system {
         EventEmitter() = default;
 
         explicit EventEmitter(const std::shared_ptr<EventManager>& manager) :
-                event_manager(manager) {}
+                event_manager_(manager) {}
 
-        virtual ~EventEmitter() = default;
+        ~EventEmitter() = default;
 
         /**
          * @brief Emit an event on the registered event manager.
@@ -41,13 +41,13 @@ namespace event_system {
                 return;
             }
 
-            if (auto shared_manager = event_manager.lock()) {
+            if (auto shared_manager = event_manager_.lock()) {
                 shared_manager->EmitEvent(event);
             }
         }
 
         std::shared_ptr<EventManager> get_event_manager() {
-            return event_manager.lock();
+            return event_manager_.lock();
         }
 
     protected:
@@ -63,7 +63,7 @@ namespace event_system {
         }
 
     private:
-        std::weak_ptr<EventManager> event_manager;
+        std::weak_ptr<EventManager> event_manager_;
     };
 
 }

--- a/src/single_layer.cpp
+++ b/src/single_layer.cpp
@@ -5,48 +5,46 @@
 #include "event_layer.h"
 #include "event_listener.h"
 #include "base_event.h"
-#include "event_emitter.h"
 #include <string>
 
 using namespace event_system;
 
+enum class GeneralEvents {
+    GeneralSubType0,
+    GeneralSubType1,
+};
+
+enum class SpecificEvents {
+    SpecificSubType0,
+    SpecificSubType1,
+};
+
 class GeneralEvent : public BaseEvent {
 public:
-    enum class SubType {
-        GeneralSubType0,
-        GeneralSubType1,
-    };
-
-    explicit GeneralEvent(SubType sub_type) : sub_type_(sub_type) {
-        event_name = "GeneralEvent";
+    explicit GeneralEvent(GeneralEvents sub_type) : sub_type_(sub_type) {
+        event_name_ = "GeneralEvent";
     }
 
-    [[nodiscard]] int get_sub_type() const override {
-        return static_cast<int>(sub_type_);
+    [[nodiscard]] GeneralEvents get_sub_type() const {
+        return sub_type_;
     }
-
 
 private:
-    SubType sub_type_;
+    GeneralEvents sub_type_;
 };
 
 class SpecificEvent : public BaseEvent {
 public:
-    enum class SubType {
-        SpecificSubType0,
-        SpecificSubType1,
-    };
-
-    explicit SpecificEvent(SubType sub_type) : sub_type_(sub_type) {
-        event_name = "SpecificEvent";
+    explicit SpecificEvent(SpecificEvents sub_type) : sub_type_(sub_type) {
+        event_name_ = "SpecificEvent";
     }
 
-    [[nodiscard]] int get_sub_type() const override {
-        return static_cast<int>(sub_type_);
+    [[nodiscard]] SpecificEvents get_sub_type() const {
+        return sub_type_;
     }
 
 private:
-    SubType sub_type_;
+    SpecificEvents sub_type_;
 };
 
 class SampleLayer1 : public EventLayer {
@@ -56,10 +54,10 @@ public:
         std::shared_ptr<EventListener<GeneralEvent>>
                 general_listener_1 = std::make_shared<EventListener<GeneralEvent>>();
 
-        AddListener(general_listener_1);
+        AddEventListener(general_listener_1);
 
-        GeneralEvent general_event_1{GeneralEvent::SubType::GeneralSubType1};
-        SpecificEvent specific_event_0{SpecificEvent::SubType::SpecificSubType0};
+        GeneralEvent general_event_1{GeneralEvents::GeneralSubType1};
+        SpecificEvent specific_event_0{SpecificEvents::SpecificSubType0};
 
         TriggerEvent(specific_event_0); // Should not emit an event
         TriggerEvent(general_event_1);

--- a/tests/test_event_emitter.cpp
+++ b/tests/test_event_emitter.cpp
@@ -35,7 +35,7 @@ TEST_F(EventEmitterTest, ValidEventEmissionTest) {
     std::shared_ptr<EventListener<GeneralEvent>> general_event_listener = std::make_shared<TestEventListener<GeneralEvent>>();
     event_manager->AddSubscriber(general_event_listener);
 
-    GeneralEvent general_event{GeneralEvent::SubType::GeneralSubType0};
+    GeneralEvent general_event{GeneralEvents::GeneralSubType0};
     event_emitter.Emit(general_event, true);
 
     auto casted_listener = std::static_pointer_cast<TestEventListener<GeneralEvent>>(general_event_listener);
@@ -46,7 +46,7 @@ TEST_F(EventEmitterTest, InvalidEventEmissionTest) {
     std::shared_ptr<EventListener<GeneralEvent>> general_event_listener = std::make_shared<TestEventListener<GeneralEvent>>();
     event_manager->AddSubscriber(general_event_listener);
 
-    GeneralEvent general_event{GeneralEvent::SubType::GeneralSubType0};
+    GeneralEvent general_event{GeneralEvents::GeneralSubType0};
     SpecificOnlyEventEmitter specific_event_emitter{event_manager};
 
     specific_event_emitter.Emit(general_event);

--- a/tests/test_event_layer.cpp
+++ b/tests/test_event_layer.cpp
@@ -23,7 +23,7 @@ public:
         std::shared_ptr<EventListener<GeneralEvent>>
                 general_listener = std::make_shared<EventListener<GeneralEvent>>();
 
-        AddListener(general_listener);
+        AddEventListener(general_listener);
     }
 };
 
@@ -38,8 +38,8 @@ public:
         std::shared_ptr<EventListener<GeneralEvent>>
                 general_listener = std::make_shared<EventListener<GeneralEvent>>();
 
-        AddListener(general_listener);
-        RemoveListener(general_listener);
+        AddEventListener(general_listener);
+        RemoveEventListener(general_listener);
     }
 };
 

--- a/tests/test_event_listener.cpp
+++ b/tests/test_event_listener.cpp
@@ -19,8 +19,8 @@ protected:
 };
 
 TEST_F(EventListenerTest, DerivedOnEventTriggeredTest) {
-    GeneralEvent general_event{GeneralEvent::SubType::GeneralSubType0};
-    auto casted_general_event_listener = std::dynamic_pointer_cast<TestEventListener<GeneralEvent>>(general_event_listener);
+    GeneralEvent general_event{GeneralEvents::GeneralSubType0};
+    std::shared_ptr<TestEventListener<GeneralEvent>>  casted_general_event_listener = std::dynamic_pointer_cast<TestEventListener<GeneralEvent>>(general_event_listener);
     casted_general_event_listener->OnEvent(general_event, true);
 
     EXPECT_TRUE(casted_general_event_listener->event_triggered);

--- a/tests/test_event_manager.cpp
+++ b/tests/test_event_manager.cpp
@@ -5,7 +5,6 @@
 #include "gtest/gtest.h"
 #include "event_manager.h"
 #include "base_event.h"
-#include "event_listener.h"
 #include "testing_utils.h"
 #include <memory>
 
@@ -55,7 +54,7 @@ TEST_F(EventManagerTest, RemoveSubscriberFromEmptyMapTest) {
 
 TEST_F(EventManagerTest, TriggerEventTest) {
     local_event_manager->AddSubscriber(general_event_listener);
-    GeneralEvent general_event{GeneralEvent::SubType::GeneralSubType0};
+    GeneralEvent general_event{GeneralEvents::GeneralSubType0};
 
     auto casted_listener = std::static_pointer_cast<TestEventListener<GeneralEvent>>(general_event_listener);
     auto casted_manager = std::static_pointer_cast<TestEventManager>(local_event_manager);
@@ -76,7 +75,7 @@ TEST_F(EventManagerTest, TriggerEventMultipleSubscriberTest) {
     EXPECT_FALSE(castedListener->event_triggered);
     EXPECT_FALSE(castedListener2->event_triggered);
 
-    GeneralEvent generalEvent{GeneralEvent::SubType::GeneralSubType0};
+    GeneralEvent generalEvent{GeneralEvents::GeneralSubType0};
 
     auto casted_manager = std::static_pointer_cast<TestEventManager>(local_event_manager);
     casted_manager->EmitEvent<GeneralEvent>(generalEvent, true);
@@ -88,7 +87,7 @@ TEST_F(EventManagerTest, DanglingPointerTest) {
     local_event_manager->AddSubscriber(general_event_listener);
     general_event_listener.reset();
 
-    GeneralEvent generalEvent{GeneralEvent::SubType::GeneralSubType0};
+    GeneralEvent generalEvent{GeneralEvents::GeneralSubType0};
     auto casted_manager = std::static_pointer_cast<TestEventManager>(local_event_manager);
     casted_manager->EmitEvent<GeneralEvent>(generalEvent, true);
 

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -10,43 +10,42 @@
 
 namespace event_system {
 
+    enum class GeneralEvents {
+        GeneralSubType0,
+        GeneralSubType1,
+    };
+
+    enum class SpecificEvents {
+        SpecificSubType0,
+        SpecificSubType1,
+    };
+
     class GeneralEvent : public BaseEvent {
     public:
-        enum class SubType {
-            GeneralSubType0,
-            GeneralSubType1,
-        };
-
-        explicit GeneralEvent(SubType sub_type) : sub_type_(sub_type) {
-            event_name = "GeneralEvent";
+        explicit GeneralEvent(GeneralEvents sub_type) : sub_type_(sub_type) {
+            event_name_ = "GeneralEvent";
         }
 
-        [[nodiscard]] int get_sub_type() const override {
-            return static_cast<int>(sub_type_);
+        [[nodiscard]] GeneralEvents get_sub_type() const {
+            return sub_type_;
         }
-
 
     private:
-        SubType sub_type_;
+        GeneralEvents sub_type_;
     };
 
     class SpecificEvent : public BaseEvent {
     public:
-        enum class SubType {
-            SpecificSubType0,
-            SpecificSubType1,
-        };
-
-        explicit SpecificEvent(SubType sub_type) : sub_type_(sub_type) {
-            event_name = "SpecificEvent";
+        explicit SpecificEvent(SpecificEvents sub_type) : sub_type_(sub_type) {
+            event_name_ = "SpecificEvent";
         }
 
-        [[nodiscard]] int get_sub_type() const override {
-            return static_cast<int>(sub_type_);
+        [[nodiscard]] SpecificEvents get_sub_type() const {
+            return sub_type_;
         }
 
     private:
-        SubType sub_type_;
+        SpecificEvents sub_type_;
     };
 
     template<typename TEvent>
@@ -56,7 +55,7 @@ namespace event_system {
 
         void OnEvent(const TEvent& event, bool is_test) {
             event_triggered = true;
-            std::cout << "Received event: " << event.get_sub_type() << std::endl;
+            std::cout << "Received event: " << std::endl;
         }
     };
 
@@ -67,8 +66,8 @@ namespace event_system {
         void EmitEvent(const TEvent &event, bool is_test) {
 
             // Without this check, an empty vector would be created, and we would loop over an empty container
-            auto it = get_event_map_iterator(typeid(event));
-            if (it == subscribers.end()) { return; }
+            auto it = subscribers_.find(typeid(event));
+            if (it == subscribers_.end()) { return; }
 
             // Iterate through the collection of weak_pointers
             // If we can lock the pointer, call the OnEvent method on the listener


### PR DESCRIPTION
## Description

This is a cleanup PR. Most of the changes involve renaming variables to match the projects conventions. Besides style changes, events and listeners were slightly modified and even subtypes are not part of the base interface anymore. 

## Decisions

Event subtypes were removed for now in the base event class. In future PRs I will try and address the current issue we have where the use of polymorphism for event listeners does not allow us to create templated events.

## Major Changes
- [ / ] Added an EventHandler class. Added prematurely but I am currently considering simplifying the event flow