### PR TITLE
Bitmask for allowed events

### DIFF
--- a/examples/single_layer.cpp
+++ b/examples/single_layer.cpp
@@ -11,11 +11,11 @@
 
 using namespace event_system;
 
-class GeneralEvent : public BaseEvent {
+class SGeneralEvent : public BaseEvent {
 public:
     EVENT_CLASS_TYPE(GeneralEvent)
 
-    explicit GeneralEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
+    explicit SGeneralEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
 
     [[nodiscard]] std::string get_name() const override {
         return "General Event 1";
@@ -29,11 +29,11 @@ private:
     std::string sender_id_;
 };
 
-class SpecificEvent : public BaseEvent {
+class SSpecificEvent : public BaseEvent {
 public:
     EVENT_CLASS_TYPE(SpecificEvent)
 
-    explicit SpecificEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
+    explicit SSpecificEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
 
     [[nodiscard]] std::string get_name() const override {
         return "Specific Event 1";
@@ -47,8 +47,8 @@ private:
     std::string sender_id_;
 };
 
-class GeneralEventHandler : public IEventHandler<GeneralEvent> {
-    void HandleEvent(const GeneralEvent& event) override {
+class GeneralEventHandler : public IEventHandler<SGeneralEvent> {
+    void HandleEvent(const SGeneralEvent& event) override {
         std::cout << "General event handled\n";
     }
 };
@@ -57,13 +57,13 @@ class SampleLayer : public EventLayer {
 public:
 
     void Run() override {
-        std::shared_ptr<IEventHandler<GeneralEvent>>
+        std::shared_ptr<IEventHandler<SGeneralEvent>>
                 general_handler_1 = std::make_shared<GeneralEventHandler>();
 
         AddEventHandler(general_handler_1);
 
-        GeneralEvent general_event_1{get_layer_name()};
-        SpecificEvent specific_event_0{get_layer_name()};
+        SGeneralEvent general_event_1{get_layer_name()};
+        SSpecificEvent specific_event_0{get_layer_name()};
 
         TriggerEvent(specific_event_0); // Should not emit an event
         TriggerEvent(general_event_1);

--- a/include/base_event.h
+++ b/include/base_event.h
@@ -8,11 +8,10 @@
 
 namespace event_system {
 
-    enum class EventType {
-        None = 0,
-        GeneralEvent,
-        SpecificEvent
-        // ...
+    enum EventType {
+        None                  = 0,
+        GeneralEvent          = 1 << 0,   // 1
+        SpecificEvent         = 1 << 1,   // 2
     };
 
 #define EVENT_CLASS_TYPE(type) \

--- a/include/event_layer.h
+++ b/include/event_layer.h
@@ -73,12 +73,21 @@ namespace event_system {
         size_t get_handler_count() const;
 
         /**
+         * @brief Set which events are allowed to be emitted within this layer
+         *
+         * @param event_mask Integer representing the event or events that should be allowed
+         */
+        void set_allowed_events(int event_mask) {
+            allowed_events_ = event_mask;
+        }
+
+        /**
          * @brief Checks if this object is allowed to emit the given event type
          *
          * @param event The event to check.
          * @returns True if the event type is allowed.
          */
-        virtual bool IsAllowedEvent(const BaseEvent& event);
+         bool IsAllowedEvent(const BaseEvent& event) const;
 
     protected:
 
@@ -118,6 +127,7 @@ namespace event_system {
         EventCallback layer_manager_callback_;  // Callback to the LayerEventManager::OnEvent method
         std::string layer_name_;
         std::atomic<bool> should_stop_;
+        int allowed_events_;
     };
 
 }

--- a/src/event_layer.cpp
+++ b/src/event_layer.cpp
@@ -6,7 +6,9 @@
 
 namespace event_system {
 
-    EventLayer::EventLayer(std::string layer_name) : layer_name_(std::move(layer_name)) {}
+    EventLayer::EventLayer(std::string layer_name) : layer_name_(std::move(layer_name)) {
+        allowed_events_ = ~None;
+    }
 
     void EventLayer::Stop() {
         should_stop_ = true;
@@ -40,9 +42,8 @@ namespace event_system {
         return should_stop_;
     }
 
-    bool EventLayer::IsAllowedEvent(const BaseEvent& event) {
-        // By default, all event types are allowed
-        return true;
+    bool EventLayer::IsAllowedEvent(const BaseEvent& event) const {
+        return (allowed_events_ & event.get_event_type()) != 0;
     }
 
     void EventLayer::TriggerEvent(const BaseEvent& event) {

--- a/tests/test_event_handler.cpp
+++ b/tests/test_event_handler.cpp
@@ -10,27 +10,27 @@ using namespace event_system;
 
 class EventHandlerTest : public ::testing::Test {
 protected:
-    std::shared_ptr<IEventHandler<GeneralEvent>> general_event_handler;
+    std::shared_ptr<IEventHandler<TestGeneralEvent>> general_event_handler;
 
     void SetUp() override {
-        general_event_handler = std::make_shared<TestEventHandler<GeneralEvent>>();
+        general_event_handler = std::make_shared<TestEventHandler<TestGeneralEvent>>();
     }
 };
 
 TEST_F(EventHandlerTest, DerivedOnEventTriggeredTest) {
-    GeneralEvent general_event{};
+    TestGeneralEvent general_event{};
     general_event_handler->OnEvent(general_event);
 
-    auto casted_event_handler = std::static_pointer_cast<TestEventHandler<GeneralEvent>>(general_event_handler);
+    auto casted_event_handler = std::static_pointer_cast<TestEventHandler<TestGeneralEvent>>(general_event_handler);
     EXPECT_TRUE(casted_event_handler->event_triggered);
 }
 
 // Disabled for now as I opted to use a static cast in the event handler class
 TEST_F(EventHandlerTest, DISABLED_ProperEventTypeTest) {
-    SpecificEvent specificEvent{};
+    TestSpecificEvent specificEvent{};
     general_event_handler->OnEvent(specificEvent);
 
-    auto casted_event_handler = std::static_pointer_cast<TestEventHandler<GeneralEvent>>(general_event_handler);
+    auto casted_event_handler = std::static_pointer_cast<TestEventHandler<TestGeneralEvent>>(general_event_handler);
 
     EXPECT_FALSE(casted_event_handler->event_triggered);
 }

--- a/tests/test_event_manager.cpp
+++ b/tests/test_event_manager.cpp
@@ -13,11 +13,11 @@ using namespace event_system;
 class EventManagerTest : public ::testing::Test {
 protected:
     std::shared_ptr<EventManager> local_event_manager;
-    std::shared_ptr<IEventHandler<GeneralEvent>> general_event_handler;
+    std::shared_ptr<IEventHandler<TestGeneralEvent>> general_event_handler;
 
     void SetUp() override {
         local_event_manager = std::make_shared<EventManager>();
-        general_event_handler = std::make_shared<TestEventHandler<GeneralEvent>>();
+        general_event_handler = std::make_shared<TestEventHandler<TestGeneralEvent>>();
     }
 };
 
@@ -34,7 +34,7 @@ TEST_F(EventManagerTest, AddDuplicateSubscriberTest) {
 
 TEST_F(EventManagerTest, MultipleSubscriberTest) {
     local_event_manager->AddHandler(general_event_handler);
-    std::shared_ptr<IEventHandler<GeneralEvent>> general_handler_2 = std::make_shared<TestEventHandler<GeneralEvent>>();
+    std::shared_ptr<IEventHandler<TestGeneralEvent>> general_handler_2 = std::make_shared<TestEventHandler<TestGeneralEvent>>();
     local_event_manager->AddHandler(general_handler_2);
 
     ASSERT_EQ(local_event_manager->get_handler_count(), 2);
@@ -54,9 +54,9 @@ TEST_F(EventManagerTest, RemoveSubscriberFromEmptyMapTest) {
 
 TEST_F(EventManagerTest, TriggerEventTest) {
     local_event_manager->AddHandler(general_event_handler);
-    GeneralEvent general_event{};
+    TestGeneralEvent general_event{};
 
-    auto casted_handler = std::static_pointer_cast<TestEventHandler<GeneralEvent>>(general_event_handler);
+    auto casted_handler = std::static_pointer_cast<TestEventHandler<TestGeneralEvent>>(general_event_handler);
 
     EXPECT_FALSE(casted_handler->event_triggered);
     local_event_manager->EmitEvent(general_event);
@@ -65,16 +65,16 @@ TEST_F(EventManagerTest, TriggerEventTest) {
 
 TEST_F(EventManagerTest, TriggerEventMultipleSubscriberTest) {
     local_event_manager->AddHandler(general_event_handler);
-    std::shared_ptr<IEventHandler<SpecificEvent>> specific_event_handler = std::make_shared<TestEventHandler<SpecificEvent>>();
+    std::shared_ptr<IEventHandler<TestSpecificEvent>> specific_event_handler = std::make_shared<TestEventHandler<TestSpecificEvent>>();
     local_event_manager->AddHandler(specific_event_handler);
 
-    auto casted_handler = std::static_pointer_cast<TestEventHandler<GeneralEvent>>(general_event_handler);
-    auto casted_handler_2 = std::static_pointer_cast<TestEventHandler<SpecificEvent>>(specific_event_handler);
+    auto casted_handler = std::static_pointer_cast<TestEventHandler<TestGeneralEvent>>(general_event_handler);
+    auto casted_handler_2 = std::static_pointer_cast<TestEventHandler<TestSpecificEvent>>(specific_event_handler);
 
     EXPECT_FALSE(casted_handler->event_triggered);
     EXPECT_FALSE(casted_handler_2->event_triggered);
 
-    GeneralEvent generalEvent{};
+    TestGeneralEvent generalEvent{};
 
     local_event_manager->EmitEvent(generalEvent);
     EXPECT_TRUE(casted_handler->event_triggered);
@@ -85,7 +85,7 @@ TEST_F(EventManagerTest, DanglingPointerTest) {
     local_event_manager->AddHandler(general_event_handler);
     general_event_handler.reset();
 
-    GeneralEvent generalEvent{};
+    TestGeneralEvent generalEvent{};
     local_event_manager->EmitEvent(generalEvent);
 
     ASSERT_EQ(local_event_manager->get_handler_count(EventType::GeneralEvent), 0);

--- a/tests/testing_utils.h
+++ b/tests/testing_utils.h
@@ -10,11 +10,11 @@
 
 namespace event_system {
 
-    class GeneralEvent : public BaseEvent {
+    class TestGeneralEvent : public BaseEvent {
     public:
         EVENT_CLASS_TYPE(GeneralEvent)
 
-        explicit GeneralEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
+        explicit TestGeneralEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
 
         [[nodiscard]] std::string get_name() const override {
             return "General Event 1";
@@ -28,11 +28,11 @@ namespace event_system {
         std::string sender_id_;
     };
 
-    class SpecificEvent : public BaseEvent {
+    class TestSpecificEvent : public BaseEvent {
     public:
         EVENT_CLASS_TYPE(SpecificEvent)
 
-        explicit SpecificEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
+        explicit TestSpecificEvent(std::string sender_id = "") : sender_id_(std::move(sender_id)) {}
 
         [[nodiscard]] std::string get_name() const override {
             return "Specific Event 1";


### PR DESCRIPTION
## Description

Simple change that adds a way to set which event types are allowed to be emitted from a certain layer. I decided to use a bit mask in order to select the events that are allowed. To make this possible I changed the EventType enum back to a plain enum and increment the values of each element by 2.

## Major Changes
- [ / ] Modified the EventType enum to allow for bit mask functionality
- [ / ] Added a setter in the EventLayer for allowed types